### PR TITLE
Fix ALV read silently dropping/corrupting off-screen rows

### DIFF
--- a/src/mcp_sap_gui/tables.py
+++ b/src/mcp_sap_gui/tables.py
@@ -174,6 +174,43 @@ class TablesMixin:
                 "Could not read table",
             )
 
+    def _read_alv_rows(self, grid, columns, start_row, end_row):
+        """Read ALV rows in [start_row, end_row), scrolling so every row renders.
+
+        GuiGridView.GetCellValue(row, col) only returns a real value when ``row``
+        is inside the grid's currently rendered scroll window; for off-screen rows
+        it returns a placeholder (the internal row handle, e.g. "0000000062").
+        We advance ``firstVisibleRow`` one visible-window at a time so each row is
+        rendered before we read it. Without this, an ALV read past the first
+        screenful silently drops or corrupts every off-screen row.
+        """
+        try:
+            visible = int(grid.VisibleRowCount)
+        except Exception:
+            visible = 0
+        if visible < 1:
+            visible = 1
+
+        data = []
+        row = start_row
+        while row < end_row:
+            try:
+                grid.firstVisibleRow = row
+            except Exception:
+                pass
+            window_end = min(row + visible, end_row)
+            for r in range(row, window_end):
+                row_data = {}
+                for col in columns:
+                    try:
+                        row_data[col] = grid.GetCellValue(r, col)
+                    except Exception:
+                        row_data[col] = None
+                row_data["_absolute_row_index"] = r
+                data.append(row_data)
+            row = window_end
+        return data
+
     def _read_alv_grid(self, grid, table_id: str, max_rows: int,
                        col_filter: List[str] = None,
                        columns_only: bool = False,
@@ -209,15 +246,7 @@ class TablesMixin:
         start_row = max(0, start_row)
         if not columns_only:
             end_row = min(start_row + max_rows, grid.RowCount)
-            for row in range(start_row, end_row):
-                row_data = {}
-                for col in columns:
-                    try:
-                        row_data[col] = grid.GetCellValue(row, col)
-                    except Exception:
-                        row_data[col] = None
-                row_data["_absolute_row_index"] = row
-                data.append(row_data)
+            data = self._read_alv_rows(grid, columns, start_row, end_row)
 
         result = {
             "table_id": table_id,

--- a/tests/test_sap_controller.py
+++ b/tests/test_sap_controller.py
@@ -777,6 +777,56 @@ class TestGridEnhancements:
         for i, row in enumerate(result["data"]):
             assert row["_absolute_row_index"] == i
 
+    def test_read_table_alv_scrolls_to_render_offscreen_rows(self):
+        """ALV read scrolls so off-screen rows render before GetCellValue.
+
+        GuiGridView.GetCellValue only returns a real value for rows inside the
+        currently rendered scroll window; off-screen rows yield the internal row
+        handle ("0000000062"-style). Reading a grid taller than one screen must
+        advance firstVisibleRow so every row renders, otherwise off-screen rows
+        are silently dropped or corrupted. This simulates a 67-row grid with a
+        16-row visible window.
+        """
+        controller = self._make_controller_with_session()
+        total_rows = 67
+        visible = 16
+        mock_grid = MagicMock()
+        mock_grid.ColumnCount = 1
+        mock_grid.ColumnOrder.return_value = "MATNR"
+        mock_grid.GetColumnTooltip.return_value = ""
+        mock_grid.GetDisplayedColumnTitle.return_value = "Material"
+        mock_grid.RowCount = total_rows
+        mock_grid.VisibleRowCount = visible
+
+        # Track the rendered window via firstVisibleRow assignments. SAP clamps
+        # the value so the last window cannot scroll past RowCount - visible.
+        state = {"first": 0}
+
+        def set_first(value):
+            state["first"] = min(value, total_rows - visible)
+
+        type(mock_grid).firstVisibleRow = property(
+            lambda self: state["first"], lambda self, v: set_first(v)
+        )
+
+        def get_cell_value(row, col):
+            window_start = state["first"]
+            if window_start <= row < window_start + visible:
+                return f"MAT{row:03d}"
+            return "0000000062"  # off-screen placeholder handle
+
+        mock_grid.GetCellValue.side_effect = get_cell_value
+        controller._session.findById.return_value = mock_grid
+
+        result = controller.read_table("wnd[0]/usr/grid", max_rows=total_rows)
+
+        assert len(result["data"]) == total_rows
+        for i, row in enumerate(result["data"]):
+            assert row["_absolute_row_index"] == i
+            assert row["MATNR"] == f"MAT{i:03d}"
+        # No row should contain the off-screen placeholder handle.
+        assert all(row["MATNR"] != "0000000062" for row in result["data"])
+
     def test_alv_toolbar_includes_tooltip_and_enabled(self):
         """get_alv_toolbar now includes tooltip and enabled per button."""
         controller = self._make_controller_with_session()


### PR DESCRIPTION
## Problem

`sap_read_table` silently returns incomplete/garbled data for any ALV grid
(`GuiGridView`) that has more rows than fit on screen.

`GuiGridView.GetCellValue(row, col)` only returns a valid value when `row` is
within the grid's currently *rendered* scroll window. For rows past the first
screenful, it returns a placeholder — the internal row handle, e.g.
`"0000000062"` — or an empty string. `_read_alv_grid` iterates
`range(start_row, end_row)` calling `GetCellValue` without scrolling, so every
off-screen row is dropped or corrupted, and **no error is raised** — callers
believe they read the whole table.

### Repro
Open any ALV report with, say, 60+ rows (e.g. `CATS_DA`) and call
`sap_read_table`. Rows beyond the visible window come back blank or contain the
`0000000062`-style handle in their string cells.

## Fix

Add `_read_alv_rows`, which advances `firstVisibleRow` one visible-window at a
time so each row is rendered before `GetCellValue` reads it, and use it from
`_read_alv_grid`. Pure read-path change; no API or signature changes.

## Testing

Verified against a live 67-row ALV: all 67 rows now read correctly. Before the
fix, 6 off-screen rows were dropped or garbled (1 row's string cells returned
`0000000062`, 5 rows came back entirely blank).
