### PR TITLE
ci: bump checkout to v5 and setup-python to v6 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -43,10 +43,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## Why

`actions/checkout@v4` and `actions/setup-python@v5` run on the Node 20 runtime, which GitHub is deprecating: Actions will be forced to Node 24 on **2026-06-16**, and Node 20 is removed from runners on **2026-09-16**. CI surfaced the deprecation warning on PR #15.

## What

Bump to the Node 24 majors across all three workflows:
- `actions/checkout@v4` → `@v5`
- `actions/setup-python@v5` → `@v6`

Files: `ci.yml`, `docs.yml`, `release.yml` (8 occurrences).

Left as-is (not flagged, already current majors): `upload-artifact@v4`, `download-artifact@v4`, `softprops/action-gh-release@v2`.

No workflow logic changes — version bumps only.